### PR TITLE
UCM configurations for mido, ysl and generic enable, disable sequences for msm8953 devices

### DIFF
--- a/ucm2/Xiaomi/mido/HiFi.conf
+++ b/ucm2/Xiaomi/mido/HiFi.conf
@@ -1,0 +1,135 @@
+# Use case configuration for Xiaomi Redmi Note 4
+# All analog outputs/inputs connected to internal PM8953 codec,
+# speaker connected via AW87318CSR amplifier to Lineout.
+
+SectionVerb {
+	EnableSequence [
+		cset "name='PRI_MI2S_RX Audio Mixer MultiMedia1' 1"
+		cset "name='MultiMedia2 Mixer TERT_MI2S_TX' 1"
+	]
+	DisableSequence [
+		cset "name='PRI_MI2S_RX Audio Mixer MultiMedia1' 0"
+		cset "name='MultiMedia2 Mixer TERT_MI2S_TX' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	ConflictingDevice [
+		"Earpiece"
+	]
+
+	EnableSequence [
+		cset "name='LINEOUT' 1"
+		cset "name='RX3 MIX1 INP1' RX1"
+	]
+
+	DisableSequence [
+		cset "name='LINEOUT' ZERO"
+		cset "name='RX3 MIX1 INP1' ZERO"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 200
+		PlaybackChannels 2
+	}
+}
+
+SectionDevice."Earpiece" {
+	Comment "Earpiece playback"
+
+	ConflictingDevice [
+		"Speaker"
+		"Headphones"
+	]
+
+	Include.ees.File "/codecs/msm8953-wcd/EarpieceEnableSeq.conf"
+	Include.eds.File "/codecs/msm8953-wcd/EarpieceDisableSeq.conf"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+		PlaybackChannels 2
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones playback"
+
+	ConflictingDevice [
+		"Speaker"
+		"Earpiece"
+	]
+
+	Include.hpes.File "/codecs/msm8953-wcd/HeadphonesEnableSeq.conf"
+	Include.hpds.File "/codecs/msm8953-wcd/HeadphonesDisableSeq.conf"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 300
+		PlaybackChannels 2
+		JackControl "Headset Jack"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Primary Microphone"
+
+	ConflictingDevice [
+		"Headset"
+		"Mic2"
+	]
+
+	Include.pmes.File "/codecs/msm8953-wcd/PrimaryMicEnableSeq.conf"
+	Include.pmds.File "/codecs/msm8953-wcd/PrimaryMicDisableSeq.conf"
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CaptureChannels 2
+		CapturePriority 300
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Secondary Microphone"
+
+	ConflictingDevice [
+		"Headset"
+		"Mic1"
+	]
+
+	Include.smes.File "/codecs/msm8953-wcd/SecondaryMicEnableSeq.conf"
+	Include.smds.File "/codecs/msm8953-wcd/SecondaryMicDisableSeq.conf"
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CaptureChannels 2
+		CapturePriority 200
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
+
+	Include.smes.File "/codecs/msm8953-wcd/HeadsetMicEnableSeq.conf"
+	Include.smds.File "/codecs/msm8953-wcd/HeadsetMicDisableSeq.conf"
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CaptureChannels 2
+		CapturePriority 400
+		JackControl "Headset Jack"
+	}
+}
+

--- a/ucm2/codecs/msm8953-wcd/EarpieceDisableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/EarpieceDisableSeq.conf
@@ -1,0 +1,4 @@
+DisableSequence [
+	cset "name='RX1 MIX1 INP1' ZERO"
+	cset "name='EAR_S' 0"
+]

--- a/ucm2/codecs/msm8953-wcd/EarpieceEnableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/EarpieceEnableSeq.conf
@@ -1,0 +1,5 @@
+EnableSequence [
+	cset "name='RX1 MIX1 INP1' RX1"
+	cset "name='RDAC2 MUX' RX1"
+	cset "name='EAR_S' 1"
+]

--- a/ucm2/codecs/msm8953-wcd/HeadphonesDisableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/HeadphonesDisableSeq.conf
@@ -1,0 +1,6 @@
+DisableSequence [
+	cset "name='HPHL' 0"
+	cset "name='HPHR' 0"
+	cset "name='RX1 MIX1 INP1' ZERO"
+	cset "name='RX2 MIX1 INP1' ZERO"
+]

--- a/ucm2/codecs/msm8953-wcd/HeadphonesEnableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/HeadphonesEnableSeq.conf
@@ -1,0 +1,7 @@
+EnableSequence [
+	cset "name='RX1 MIX1 INP1' RX1"
+	cset "name='RX2 MIX1 INP1' RX2"
+	cset "name='RDAC2 MUX' RX2"
+	cset "name='HPHL' 1"
+	cset "name='HPHR' 1"
+]

--- a/ucm2/codecs/msm8953-wcd/HeadsetMicDisableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/HeadsetMicDisableSeq.conf
@@ -1,0 +1,4 @@
+DisableSequence [
+	cset "name='ADC2 MUX' ZERO"
+	cset "name='DEC1 MUX' ZERO"
+]

--- a/ucm2/codecs/msm8953-wcd/HeadsetMicEnableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/HeadsetMicEnableSeq.conf
@@ -1,0 +1,5 @@
+EnableSequence [
+	cset "name='DEC1 MUX' ADC2"
+	cset "name='CIC1 MUX' AMIC"
+	cset "name='ADC2 MUX' INP2"
+]

--- a/ucm2/codecs/msm8953-wcd/PrimaryMicDisableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/PrimaryMicDisableSeq.conf
@@ -1,0 +1,3 @@
+DisableSequence [
+	cset "name='DEC1 MUX' ZERO"
+]

--- a/ucm2/codecs/msm8953-wcd/PrimaryMicEnableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/PrimaryMicEnableSeq.conf
@@ -1,0 +1,4 @@
+EnableSequence [
+	cset "name='DEC1 MUX' ADC1"
+	cset "name='CIC1 MUX' AMIC"
+]

--- a/ucm2/codecs/msm8953-wcd/SecondaryMicDisableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/SecondaryMicDisableSeq.conf
@@ -1,0 +1,4 @@
+DisableSequence [
+	cset "name='DEC1 MUX' ZERO"
+	cset "name='ADC2 MUX' ZERO"
+]

--- a/ucm2/codecs/msm8953-wcd/SecondaryMicEnableSeq.conf
+++ b/ucm2/codecs/msm8953-wcd/SecondaryMicEnableSeq.conf
@@ -1,0 +1,5 @@
+EnableSequence [
+	cset "name='DEC1 MUX' ADC2"
+	cset "name='CIC1 MUX' AMIC"
+	cset "name='ADC2 MUX' INP3"
+]

--- a/ucm2/conf.d/xiaomi-mido/xiaomi-mido.conf
+++ b/ucm2/conf.d/xiaomi-mido/xiaomi-mido.conf
@@ -1,0 +1,27 @@
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "/Xiaomi/mido/HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+
+BootSequence [
+	# Headphones and Earpiece Volume
+	cset "name='RX1 Digital Volume' 84"
+	cset "name='RX2 Digital Volume' 84"
+
+	# Speaker Volume
+	cset "name='RX3 Digital Volume' 84"
+
+	# Headphones Mic Analog
+	cset "name='ADC2 Volume' 8"
+
+	# Primary Mic Analog
+	cset "name='ADC1 Volume' 8"
+
+	# Secondary Mic Analog
+	cset "name='ADC3 Volume' 8"
+]

--- a/ucm2/conf.d/xiaomi-ysl/xiaomi-ysl.conf
+++ b/ucm2/conf.d/xiaomi-ysl/xiaomi-ysl.conf
@@ -1,0 +1,27 @@
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "/Xiaomi/mido/HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+
+BootSequence [
+	# Headphones and Earpiece Volume
+	cset "name='RX1 Digital Volume' 84"
+	cset "name='RX2 Digital Volume' 84"
+
+	# Speaker Volume
+	cset "name='RX3 Digital Volume' 84"
+
+	# Headphones Mic Analog
+	cset "name='ADC2 Volume' 8"
+
+	# Primary Mic Analog
+	cset "name='ADC1 Volume' 8"
+
+	# Secondary Mic Analog
+	cset "name='ADC3 Volume' 8"
+]


### PR DESCRIPTION
- UCM configurations for mido and ysl
- Generic ucm sequencies for PrimaryMic, SecondaryMic, HeadsetMic, Headphone, Earpiece

Mido:
- [x] Speaker
- [x] Earpiece
- [x] Headphone
- [x] PrimaryMic
- [x] SecondaryMic
- [x] HeadsetMic

Ysl:
- [x] Speaker
- [x] Earpiece
- [x] Headphone
- [x] PrimaryMic
- [x] SecondaryMic
- [x] HeadsetMic