### PR TITLE
add xiaomi-onclite config

### DIFF
--- a/ucm2/conf.d/xiaomi-onclite/xiaomi-onclite.conf
+++ b/ucm2/conf.d/xiaomi-onclite/xiaomi-onclite.conf
@@ -1,0 +1,27 @@
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "/Xiaomi/vince/HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+
+BootSequence [
+	# Headphones and Earpiece Volume
+	cset "name='RX1 Digital Volume' 84"
+	cset "name='RX2 Digital Volume' 84"
+
+	# Speaker Volume
+	cset "name='RX3 Digital Volume' 84"
+
+	# Headphones Mic Analog
+	cset "name='ADC2 Volume' 8"
+
+	# Primary Mic Analog
+	cset "name='ADC1 Volume' 8"
+
+	# Secondary Mic Analog
+	cset "name='ADC3 Volume' 8"
+]


### PR DESCRIPTION
Initial ucm configuration for onclite, it uses vince HiFi.conf until we don't have working codec for the speaker.