### PR TITLE
add Lenovo ThinkSmart View (CD-18781) config

### DIFF
--- a/ucm2/Lenovo/cd-18781y/HiFi.conf
+++ b/ucm2/Lenovo/cd-18781y/HiFi.conf
@@ -1,0 +1,46 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='QUAT_MI2S_RX Audio Mixer MultiMedia1' 1"
+		cset "name='MultiMedia2 Mixer TERT_MI2S_TX' 1"
+	]
+	DisableSequence [
+		cset "name='QUAT_MI2S_RX Audio Mixer MultiMedia1' 0"
+		cset "name='MultiMedia2 Mixer TERT_MI2S_TX' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+		PlaybackChannels 2
+	}
+}
+
+SectionDevice."Microphone" {
+	Comment "Stereo Microphone"
+
+	EnableSequence [
+		cset "name='DEC1 MUX' DMIC1"
+		cset "name='DEC2 MUX' DMIC2"
+		cset "name='CIC1 MUX' DMIC"
+		cset "name='CIC2 MUX' DMIC"
+	]
+
+	DisableSequence [
+		cset "name='DEC1 MUX' ZERO"
+		cset "name='DEC2 MUX' ZERO"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CaptureChannels 2
+		CapturePriority 100
+	}
+}

--- a/ucm2/conf.d/cd-18781y/cd-18781y.conf
+++ b/ucm2/conf.d/cd-18781y/cd-18781y.conf
@@ -1,0 +1,17 @@
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "/Lenovo/cd-18781y/HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+
+BootSequence [
+	# DMIC1
+	cset "name='TX1 Digital Volume' 115"
+
+	# DMIC2
+	cset "name='TX2 Digital Volume' 115"
+]


### PR DESCRIPTION
This device has a speaker and two DMICs. No external audio interfaces exist.

Bluetooth SCO is connected via Secondary PCM, but mainline does not support that yet.
A patch was proposed but abandoned: https://lore.kernel.org/alsa-devel/20200207205013.12274-1-adam@serbinski.com/