### PR TITLE
Add Asus Zenfone 3 (ZE520KL/ZE552KL) config

### DIFF
--- a/ucm2/conf.d/asus-ze520kl/asus-ze520kl.conf
+++ b/ucm2/conf.d/asus-ze520kl/asus-ze520kl.conf
@@ -1,0 +1,27 @@
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "/Xiaomi/daisy/HiFi.conf"
+	Comment "Play and record HiFi quality Music"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"
+
+BootSequence [
+	# Headphones and Earpiece Volume
+	cset "name='RX1 Digital Volume' 88"
+	cset "name='RX2 Digital Volume' 88"
+
+	# Speaker Volume
+	cset "name='RX3 Digital Volume' 88"
+
+	# Headphones Mic Analog
+	cset "name='ADC2 Volume' 6"
+
+	# Primary Mic Analog
+	cset "name='ADC1 Volume' 6"
+
+	# Secondary Mic Analog
+	cset "name='ADC3 Volume' 6"
+]

--- a/ucm2/conf.d/asus-ze552kl/asus-ze552kl.conf
+++ b/ucm2/conf.d/asus-ze552kl/asus-ze552kl.conf
@@ -1,0 +1,1 @@
+../asus-ze520kl/asus-ze520kl.conf


### PR DESCRIPTION
* ~The speaker currently works only if it has been previously rebooted from the downstream kernel (3.18).~
  * fixed with tfa9895 driver
* ~The headphone jack produces significant noise when idle.~
  * it was gone, somehow

it's using Xiaomi's Daisy configuration since they have similiar configurations