### PR TITLE
Add Fairphone 3 config

### DIFF
--- a/ucm2/Fairphone/fp3/HiFi.conf
+++ b/ucm2/Fairphone/fp3/HiFi.conf
@@ -1,0 +1,26 @@
+# Use case configuration for Fairphone 3
+# Author: Luca Weiss <luca@lucaweiss.eu>
+
+SectionVerb {
+	EnableSequence [
+		cset "name='QUIN_MI2S_RX Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='QUIN_MI2S_RX Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback"
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 200
+		PlaybackChannels 2
+	}
+}

--- a/ucm2/conf.d/Fairphone_3/Fairphone_3.conf
+++ b/ucm2/conf.d/Fairphone_3/Fairphone_3.conf
@@ -1,0 +1,12 @@
+# Use case configuration for Fairphone 3
+# Author: Luca Weiss <luca@lucaweiss.eu>
+
+Syntax 6
+
+SectionUseCase."HiFi" {
+	File "/Fairphone/fp3/HiFi.conf"
+	Comment "HiFi quality Music."
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"


### PR DESCRIPTION
Add a UCM for the Fairphone 3 which uses speaker via quinary MI2S and the AW8898 amplifier (or TAS2557 on Fairphone 3+).

Earpiece, headphone jack and microphones are not supported for now.