### PR TITLE
Xiaomi/vince: add Speaker device for the TAS2557 amplifier

### DIFF
--- a/ucm2/Xiaomi/vince/HiFi.conf
+++ b/ucm2/Xiaomi/vince/HiFi.conf
@@ -1,5 +1,5 @@
-# Use case configuration for Xiaomi Redmi 5 Plus
-# TAS2557 Speaker codec not enabled yet (missing drivers).
+# Use case configuration for Xiaomi Redmi 5 Plus (vince)
+# Speaker via the TAS2557 smart amplifier on Quinary MI2S.
 
 SectionVerb {
 	EnableSequence [
@@ -52,6 +52,29 @@ SectionDevice."Headphones" {
 		PlaybackPriority 300
 		PlaybackChannels 2
 		JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker playback (TAS2557)"
+
+	ConflictingDevice [
+		"Earpiece"
+		"Headphones"
+	]
+
+	EnableSequence [
+		cset "name='QUIN_MI2S_RX Audio Mixer MultiMedia1' 1"
+	]
+
+	DisableSequence [
+		cset "name='QUIN_MI2S_RX Audio Mixer MultiMedia1' 0"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 200
+		PlaybackChannels 2
 	}
 }
 

--- a/ucm2/conf.d/xiaomi-vince/xiaomi-vince.conf
+++ b/ucm2/conf.d/xiaomi-vince/xiaomi-vince.conf
@@ -21,4 +21,7 @@ BootSequence [
 
 	# Secondary Mic Analog
 	cset "name='ADC3 Volume' 6"
+
+	# Speaker (TAS2557) — 0..15 maps to -28..+2 dB; 14 = 0 dB
+	cset "name='Speaker Playback Volume' 14"
 ]


### PR DESCRIPTION
vince already had earpiece/headphones/mics; this adds the loudspeaker, which runs through a TAS2557 smart amplifier on Quinary MI2S.

The Speaker enable sequence only sets up the audio routing (QUIN_MI2S_RX <- MultiMedia1) and conflicts with Earpiece/Headphones. Amplifier power and mute are managed entirely by the kernel driver through DAPM, so the amplifier switch control no longer exists; the boot sequence sets the amplifier's digital gain ("Speaker Playback Volume") to 0 dB.

Needs the matching kernel change (TAS2557 driver + vince DT). Tested on device (Redmi 5 Plus): playback through PipeWire/WirePlumber, clean stream start/stop cycles with no amplifier faults.